### PR TITLE
Add Pail Log storage to gitignore

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -30,6 +30,7 @@ class File implements Stringable
 
             if (! is_dir($directory)) {
                 mkdir($directory, 0755, true);
+                file_put_contents($directory . '/.gitignore', "*\n!.gitignore\n");
             }
 
             touch($this->file);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR introduces a `.gitignore` file in `storage/pail` to exclude `.pail`files from being committed to the repository.


![Screenshot 2024-05-07 at 11 36 06 AM](https://github.com/ahinkle/pail/assets/17038330/1ecabd81-cee6-441a-9065-9ddd91c9b9f4)
